### PR TITLE
Section 1.3

### DIFF
--- a/files/inactivity_check.py
+++ b/files/inactivity_check.py
@@ -1,0 +1,147 @@
+import os
+import boto3
+import datetime
+
+iam = boto3.client('iam')
+inactivity_limit = int(
+    os.environ['INACTIVITY_LIMIT']) if 'INACTIVITY_LIMIT' in os.environ else 90
+
+
+def answer_no(x): return True if str(x).lower() in [
+    '0', 'no', 'false'] else False
+
+
+def answer_yes(x): return True if str(x).lower() in [
+    '1', 'yes', 'true'] else False
+
+
+def mask_key(key):
+    masked = ""
+    if type(key) is str:
+        masked = key[:5] + '*' * (len(key) - 9) + key[-4:]
+    elif type(key) is list:
+        for i in key:
+            masked = masked + ',' + mask_key(i)
+    return masked
+
+
+def send_notifications(message):
+    # TODO
+    return True
+
+
+def is_user_logged_in(user_name):
+    user_details = iam.get_user(UserName=user_name)
+
+    if 'PasswordLastUsed' in user_details['User']:
+        last_login = user_details['User']['PasswordLastUsed']
+    else:
+        last_login = user_details['User']['CreateDate']
+
+    today = datetime.datetime.utcnow().replace(tzinfo=last_login.tzinfo)
+    last_login_delta = today - last_login
+
+    if last_login_delta.days > inactivity_limit:
+        return False
+
+    return True
+
+
+def is_access_key_used(access_key_id):
+    access_key_last_used = iam.get_access_key_last_used(
+        AccessKeyId=access_key_id)
+    # if the key is never used, there is no LastUsedDate item
+    if 'LastUsedDate' in access_key_last_used['AccessKeyLastUsed']:
+        last_used = access_key_last_used['AccessKeyLastUsed']['LastUsedDate']
+        today = datetime.datetime.utcnow().replace(tzinfo=last_used.tzinfo)
+        access_key_last_used_delta = today - last_used
+        if access_key_last_used_delta.days > inactivity_limit:
+            return False
+    return True
+
+
+def delete_credentials(users):
+    message_body = 'AGGRESSIVE is set to ' + os.environ['AGGRESSIVE'] \
+        if ('AGGRESSIVE' in os.environ and answer_yes(os.environ['AGGRESSIVE'])) \
+        else "AGGRESSIVE mode is not active"
+    print message_body
+
+    for user in users:
+        if 'DRY_RUN' not in os.environ or answer_no(os.environ['DRY_RUN']):
+            if 'AGGRESSIVE' in os.environ and answer_yes(os.environ['AGGRESSIVE']):
+                user_notification = 'Deleting ' + user + "'s login profile"
+                print user_notification
+                message_body += "\n" + user_notification
+
+                try:
+                    iam.delete_login_profile(UserName=user)
+                except Exception, e:
+                    print 'Skipping User ' + user + ' has no login profile'
+
+                try:
+                    access_keys = iam.list_access_keys(UserName=user)
+                except Exception, e:
+                    print 'Skipping. User ' + user + ' has no access key'
+
+                if 'AccessKeyMetadata' in access_keys:
+                    for key in access_keys['AccessKeyMetadata']:
+                        key_notification = 'User ' + user + "'s key " + \
+                            mask_key(key['AccessKeyId']) + ' will be deleted'
+                        print key_notification
+                        message_body = "\n" + key_notification
+                        iam.delete_access_key(
+                            UserName=key['UserName'], AccessKeyId=key['AccessKeyId'])
+            else:
+                user_notification = user + ' is not an active user, so should be disabled'
+                print user_notification
+                message_body += "\n" + user_notification
+        else:
+            no_action = "DRY_RUN has been set and the %s is not disabled" % user
+            print no_action
+            message_body += "\n" + no_action
+
+    if len(users) > 0 and ('DRY_RUN' in os.environ and answer_no(os.environ['DRY_RUN'])):
+        send_notifications(message_body)
+    else:
+        print "Nothing to do"
+
+
+def lambda_handler(event, context):
+    print 'Inactivity Limit ' + str(inactivity_limit)
+    inactive_users = []
+
+    prefix_list = os.environ['IGNORE_IAM_USER_PREFIX'].split(
+        ',') if 'IGNORE_IAM_USER_PREFIX' in os.environ else []
+    suffix_list = os.environ['IGNORE_IAM_USER_SUFFIX'].split(
+        ',') if 'IGNORE_IAM_USER_SUFFIX' in os.environ else []
+
+    def is_user_ignored(prefix_list, suffix_list, name):
+        for prefix in prefix_list:
+            if name.startswith(prefix):
+                return True
+        for prefix in suffix_list:
+            if name.endswith(prefix):
+                return True
+        return False
+
+    users = iam.list_users()
+
+    for user in users['Users']:
+        if not is_user_ignored(prefix_list, suffix_list, user['UserName']):
+            any_key_used = False
+
+            logged_in = is_user_logged_in(user['UserName'])
+
+            access_keys = iam.list_access_keys(UserName=user['UserName'])
+            for key in access_keys['AccessKeyMetadata']:
+                if is_access_key_used(key['AccessKeyId']):
+                    any_key_used = True
+
+            if not logged_in and not any_key_used:
+                inactive_users.append(user['UserName'])
+    delete_credentials(inactive_users)
+
+# if __name__ == "__main__":
+#    event = 1
+#    context = 1
+#    lambda_handler(event, context)

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,4 @@
-# main.tf has been left empty for purpose even the best pracites says
+# main.tf only contains shared resouces across the module for purpose even the best pracites says
 # keep roles as small as possible and have three files main,variables,outputs.tf
 # So, the motivation in here make the code easily readable.
 # You can open the CIS Benchmark and go step by step to verify or understand how
@@ -8,3 +8,7 @@
 #
 # So that, we decided to break down the module into files per section.
 
+# every lambda function uses this assume role policy
+data "template_file" "iam_lambda_assume_role_policy" {
+  template = "${file("${path.module}/templates/iam_lambda_assume_role_policy.json.tpl")}"
+}

--- a/section-1_2.tf
+++ b/section-1_2.tf
@@ -1,8 +1,3 @@
-# every lambda function uses this assume role policy
-data "template_file" "iam_lambda_assume_role_policy" {
-  template = "${file("${path.module}/templates/iam_lambda_assume_role_policy.json.tpl")}"
-}
-
 # MFA check and disable function
 ## IAM Policy
 data "template_file" "mfa_check_policy" {

--- a/section-1_3.tf
+++ b/section-1_3.tf
@@ -1,0 +1,74 @@
+# Inactivity check and disable function
+## IAM Policy
+data "template_file" "inactivity_check_policy" {
+  template = "${file("${path.module}/templates/lambda_inactivity_check_policy.json.tpl")}"
+}
+
+resource "aws_iam_role" "inactivity_check" {
+  name               = "${var.resource_name_prefix}-inactivity-check"
+  assume_role_policy = "${data.template_file.iam_lambda_assume_role_policy.rendered}"
+}
+
+resource "aws_iam_role_policy" "inactivity_check" {
+  name   = "${var.resource_name_prefix}-lambda-inactivity-check"
+  role   = "${aws_iam_role.inactivity_check.id}"
+  policy = "${data.template_file.inactivity_check_policy.rendered}"
+}
+
+## /IAM Policy
+
+## Create the function
+data "archive_file" "inactivity_check" {
+  type        = "zip"
+  source_file = "${path.module}/files/inactivity_check.py"
+  output_path = "${var.temp_artifacts_dir}/inactivity_check.zip"
+}
+
+resource "aws_lambda_function" "inactivity_check" {
+  filename         = "${var.temp_artifacts_dir}/inactivity_check.zip"
+  function_name    = "${var.resource_name_prefix}-inactivity-check"
+  role             = "${aws_iam_role.inactivity_check.arn}"
+  handler          = "inactivity_check.lambda_handler"
+  source_code_hash = "${data.archive_file.inactivity_check.output_base64sha256}"
+  runtime          = "python2.7"
+  timeout          = "${var.lambda_timeout}"
+
+  environment {
+    variables = {
+      DRY_RUN                = "${var.lambda_dry_run}"
+      AGGRESSIVE             = "${var.lambda_aggressive}"
+      INACTIVITY_LIMIT       = "${var.lambda_user_inactivity_limit}"
+      IGNORE_IAM_USER_PREFIX = "${var.lambda_mfa_checker_user_prefix}"
+      IGNORE_IAM_USER_SUFFIX = "${var.lambda_mfa_checker_user_suffix}"
+    }
+  }
+
+  tags = "${var.tags}"
+}
+
+## /Create the function
+
+## Schedule the lambda function
+resource "aws_cloudwatch_event_rule" "inactivity_check" {
+  name                = "${var.resource_name_prefix}-inactivity-check"
+  description         = "disables inactive users"
+  schedule_expression = "${var.lambda_cron_schedule}"
+}
+
+resource "aws_cloudwatch_event_target" "inactivity_check" {
+  rule      = "${aws_cloudwatch_event_rule.inactivity_check.name}"
+  target_id = "${var.resource_name_prefix}-inactivity-check"
+  arn       = "${aws_lambda_function.inactivity_check.arn}"
+}
+
+resource "aws_lambda_permission" "inactivity_check" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = "${aws_lambda_function.inactivity_check.function_name}"
+  principal     = "events.amazonaws.com"
+  source_arn    = "${aws_cloudwatch_event_rule.inactivity_check.arn}"
+}
+
+## /Schedule the lambda function
+# /MFA check and disable function
+

--- a/templates/lambda_inactivity_check_policy.json.tpl
+++ b/templates/lambda_inactivity_check_policy.json.tpl
@@ -1,0 +1,26 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*:*:*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:GetUser",
+        "iam:GetAccessKeyLastUsed",
+        "iam:DeleteLoginProfile",
+        "iam:ListAccessKeys",
+        "iam:DeleteAccessKey",
+        "iam:ListUsers"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,11 @@ variable "lambda_mfa_checker_user_suffix" {
   default     = ""
 }
 
+variable "lambda_user_inactivity_limit" {
+  description = "Disable inactive users more than N days"
+  default     = 90
+}
+
 variable "lambda_cron_schedule" {
   description = "Default Cron schedule for lambda helpers"
   default     = "cron(0 6 * * ? *)"


### PR DESCRIPTION
I've just finished the automation of section 1.3. Please see the what the documentation says about this section.

```
1.3 Ensure credentials unused for 90 days or greater are disabled (Scored)
Profile Applicability:
 Level 1 Description:
AWS IAM users can access AWS resources using different types of credentials, such as passwords or access keys. It is recommended that all credentials that have been unused in 90 or greater days be removed or deactivated.
Rationale:
Disabling or removing unnecessary credentials will reduce the window of opportunity for credentials associated with a compromised or abandoned account to be used.
Audit:
Perform the following to determine if unused credentials exist:
1. Login to the AWS Management Console
2. Click Services
3. Click IAM
4. Click on Credential Report
5. This will download an .xls file which contains credential usage for all users within an AWS Account - open this file
6. For each user having password_enabled set to TRUE, ensure password_last_used is less than 90 days ago.
7. For each user having access_key_1_active or access_key_2_active to TRUE, ensure the corresponding access_key_n_last_used_date is less than 90 days ago.
```

As of this is a regular job, we've automated this by the lambda function and scheduled by CloudWatch.

This function has the same AGGRESSIVE mode too.