### PR TITLE
section 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ This Terraform module helps to setup an AWS account with the requirements of  CI
     1. Avoid the use of the "root" account (Scored) - Cannot be codified
     2. Ensure multi-factor authentication (MFA) is enabled for all IAM users that have a console password (Scored)
     3. Ensure credentials unused for 90 days or greater are disabled (Scored)
+    4. Ensure access keys are rotated every 90 days or less (Scored)

--- a/files/access_key_age_check.py
+++ b/files/access_key_age_check.py
@@ -1,0 +1,113 @@
+import os
+import boto3
+import datetime
+
+iam = boto3.client('iam')
+
+
+def answer_no(x): return True if str(x).lower() in [
+    '0', 'no', 'false'] else False
+
+
+def answer_yes(x): return True if str(x).lower() in [
+    '1', 'yes', 'true'] else False
+
+
+def mask_key(key):
+    masked = ""
+    if type(key) is str:
+        masked = key[:5] + '*' * (len(key) - 10) + key[-5:]
+    elif type(key) is list:
+        for i in key:
+            masked = masked + mask_key(i)
+    return masked
+
+
+def send_notifications(message):
+    # TODO
+    return True
+
+
+def process_expring_keys(users):
+    message_body = 'AGGRESSIVE is set to ' + os.environ['AGGRESSIVE'] \
+        if ('AGGRESSIVE' in os.environ and answer_yes(os.environ['AGGRESSIVE'])) \
+        else "AGGRESSIVE mode is not active"
+    print message_body
+
+    key_age_max = int(
+        os.environ['KEY_AGE_MAX']) if 'KEY_AGE_MAX' in os.environ else 90
+    key_age_notify = int(
+        os.environ['KEY_AGE_NOTIFY']) if 'KEY_AGE_NOTIFY' in os.environ else 7
+
+    notification = 'Notify: ' + \
+        str(key_age_notify) + ', Expire: ' + str(key_age_max)
+    print notification
+    message_body += "\n" + notification
+
+    for user, access_key in users.iteritems():
+        for key_id, expirity in access_key.iteritems():
+            if expirity >= key_age_max:
+                if 'AGGRESSIVE' in os.environ and answer_yes(os.environ['AGGRESSIVE']):
+                    notification = 'Deleting ' + user + "'s key " + \
+                        mask_key(key_id) + ' due to expiration'
+                    print notification
+                    message_body += "\n" + notification
+                    iam.delete_access_key(UserName=user, AccessKeyId=key_id)
+                else:
+                    notification = user + "'s key " + \
+                        mask_key(key_id) + ' ' + str(expirity) + \
+                        ' old, so should be deleted'
+                    print notification
+                    message_body += "\n" + notification
+            elif expirity < key_age_max and expirity >= key_age_max - key_age_notify:
+                notification = user + "'s key " + mask_key(key_id) \
+                    + ' will be expiring in ' + str(expirity) + ' days.' \
+                    + 'It should be rotated soon'
+                print notification
+                message_body += "\n" + notification
+
+    if len(users) > 0 and ('DRY_RUN' in os.environ and answer_no(os.environ['DRY_RUN'])):
+        send_notifications(message_body)
+    else:
+        print "Nothing to do. Either there is no user to process or DRY_RUN is active"
+
+
+def lambda_handler(event, context):
+    users = iam.list_users()
+
+    prefix_list = os.environ['IGNORE_IAM_USER_PREFIX'].split(
+        ',') if 'IGNORE_IAM_USER_PREFIX' in os.environ else []
+    suffix_list = os.environ['IGNORE_IAM_USER_SUFFIX'].split(
+        ',') if 'IGNORE_IAM_USER_SUFFIX' in os.environ else []
+
+    def is_user_ignored(prefix_list, suffix_list, name):
+        for prefix in prefix_list:
+            if name.startswith(prefix):
+                return True
+        for prefix in suffix_list:
+            if name.endswith(prefix):
+                return True
+        return False
+
+    keys_to_process = {}
+
+    for user in users['Users']:
+        if not is_user_ignored(prefix_list, suffix_list, user['UserName']):
+            print 'Processing ' + user['UserName']
+            access_keys = iam.list_access_keys(UserName=user['UserName'])
+
+            for key in access_keys['AccessKeyMetadata']:
+                today = datetime.datetime.utcnow().replace(
+                    tzinfo=key['CreateDate'].tzinfo)
+                delta = today - key['CreateDate']
+                if key['UserName'] not in keys_to_process:
+                    keys_to_process[key['UserName']] = {}
+                keys_to_process[key['UserName']].setdefault(
+                    key['AccessKeyId'], delta.days)
+
+    process_expring_keys(keys_to_process)
+
+# if __name__ == "__main__":
+#    event = 1
+#    context = 1
+#    lambda_handler(event, context)

--- a/section-1_4.tf
+++ b/section-1_4.tf
@@ -1,0 +1,75 @@
+# AccessKey age check and delete function
+## IAM Policy
+data "template_file" "access_key_age_check_policy" {
+  template = "${file("${path.module}/templates/lambda_access_key_age_check_policy.json.tpl")}"
+}
+
+resource "aws_iam_role" "access_key_age_check" {
+  name               = "${var.resource_name_prefix}-access-key-age-check"
+  assume_role_policy = "${data.template_file.iam_lambda_assume_role_policy.rendered}"
+}
+
+resource "aws_iam_role_policy" "access_key_age_check" {
+  name   = "${var.resource_name_prefix}-lambda-access-key-age-check"
+  role   = "${aws_iam_role.access_key_age_check.id}"
+  policy = "${data.template_file.access_key_age_check_policy.rendered}"
+}
+
+## /IAM Policy
+
+## Create the function
+data "archive_file" "access_key_age_check" {
+  type        = "zip"
+  source_file = "${path.module}/files/access_key_age_check.py"
+  output_path = "${var.temp_artifacts_dir}/access_key_age_check.zip"
+}
+
+resource "aws_lambda_function" "access_key_age_check" {
+  filename         = "${var.temp_artifacts_dir}/access_key_age_check.zip"
+  function_name    = "${var.resource_name_prefix}-access-key-age-check"
+  role             = "${aws_iam_role.access_key_age_check.arn}"
+  handler          = "access_key_age_check.lambda_handler"
+  source_code_hash = "${data.archive_file.access_key_age_check.output_base64sha256}"
+  runtime          = "python2.7"
+  timeout          = "${var.lambda_timeout}"
+
+  environment {
+    variables = {
+      DRY_RUN                = "${var.lambda_dry_run}"
+      AGGRESSIVE             = "${var.lambda_aggressive}"
+      KEY_AGE_MAX            = "${var.lambda_access_key_age_max}"
+      KEY_AGE_NOTIFY         = "${var.lambda_access_key_age_notify}"
+      IGNORE_IAM_USER_PREFIX = "${var.lambda_mfa_checker_user_prefix}"
+      IGNORE_IAM_USER_SUFFIX = "${var.lambda_mfa_checker_user_suffix}"
+    }
+  }
+
+  tags = "${var.tags}"
+}
+
+## /Create the function
+
+## Schedule the lambda function
+resource "aws_cloudwatch_event_rule" "access_key_age_check" {
+  name                = "${var.resource_name_prefix}-access-key-age-check"
+  description         = "remove expiring access keys"
+  schedule_expression = "${var.lambda_cron_schedule}"
+}
+
+resource "aws_cloudwatch_event_target" "access_key_age_check" {
+  rule      = "${aws_cloudwatch_event_rule.access_key_age_check.name}"
+  target_id = "${var.resource_name_prefix}-access-key-age-check"
+  arn       = "${aws_lambda_function.access_key_age_check.arn}"
+}
+
+resource "aws_lambda_permission" "access_key_age_check" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = "${aws_lambda_function.access_key_age_check.function_name}"
+  principal     = "events.amazonaws.com"
+  source_arn    = "${aws_cloudwatch_event_rule.access_key_age_check.arn}"
+}
+
+## /Schedule the lambda function
+# /AccessKey age check and delete function
+

--- a/templates/lambda_access_key_age_check_policy.json.tpl
+++ b/templates/lambda_access_key_age_check_policy.json.tpl
@@ -1,0 +1,23 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*:*:*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:DeleteAccessKey",
+        "iam:ListUsers",
+        "iam:ListAccessKeys"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -38,6 +38,16 @@ variable "lambda_user_inactivity_limit" {
   default     = 90
 }
 
+variable "lambda_access_key_age_max" {
+  description = "Expire access keys after N days"
+  default     = 90
+}
+
+variable "lambda_access_key_age_notify" {
+  description = "Start to send notifications for expiring keys N before"
+  default     = 7
+}
+
 variable "lambda_cron_schedule" {
   description = "Default Cron schedule for lambda helpers"
   default     = "cron(0 6 * * ? *)"


### PR DESCRIPTION
```1.4 Ensure access keys are rotated every 90 days or less (Scored)
Profile Applicability:
 Level 1 Description:
Access keys consist of an access key ID and secret access key, which are used to sign programmatic requests that you make to AWS. AWS users need their own access keys to make programmatic calls to AWS from the AWS Command Line Interface (AWS CLI), Tools for Windows PowerShell, the AWS SDKs, or direct HTTP calls using the APIs for individual AWS services. It is recommended that all access keys be regularly rotated.
Rationale:
Rotating access keys will reduce the window of opportunity for an access key that is associated with a compromised or terminated account to be used.
Access keys should be rotated to ensure that data cannot be accessed with an old key which might have been lost, cracked, or stolen.
Audit:
Perform the following to determine if access keys are rotated as prescribed:
1. Login to the AWS Management Console
2. Click Services
3. Click IAM
4. Click on Credential Report
5. This will download an .xls file which contains Access Key usage for all IAM users within an AWS Account - open this file
6. Focus on the following columns (where x = 1 or 2)
         o  access_key_X_active
         o  access_key_X_last_rotated
         o  access_key_X_last_used_date
7. Ensure all active keys have been rotated within 90 days
8. Ensure all active keys have been used since last rotation
o Keys not in-use since last rotation should be disabled/deleted```