### PR TITLE
section 1.16 added

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@ This Terraform module helps to setup an AWS account with the requirements of  CI
     13. Ensure MFA is enabled for the "root" account (Scored)
     14. *TODO*: Ensure hardware MFA is enabled for the "root" account (Scored)
     15. *Ensure security questions are registered in the AWS account (Not Scored)* **Cannot be codified**
+    16. Ensure IAM policies are attached only to groups or roles (Scored)

--- a/files/user_policies_check.py
+++ b/files/user_policies_check.py
@@ -1,0 +1,70 @@
+import os
+import boto3
+
+iam = boto3.client('iam')
+
+
+def answer_no(x): return True if str(x).lower() in [
+    '0', 'no', 'false'] else False
+
+
+def answer_yes(x): return True if str(x).lower() in [
+    '1', 'yes', 'true'] else False
+
+
+def send_notifications(message):
+    # TO DO
+    return True
+
+
+def detach_policies(users):
+    message_body = 'AGGRESSIVE is set to ' + os.environ['AGGRESSIVE'] \
+        if ('AGGRESSIVE' in os.environ and answer_yes(os.environ['AGGRESSIVE'])) \
+        else 'AGGRESSIVE mode is not active'
+    print message_body
+
+    for user, policies in users.iteritems():
+        notification = 'Processing ' + user
+        print notification
+        message_body += notification + "\n"
+        for policy in policies:
+            notification = policy['PolicyName'] + \
+                ' will be detached from the user'
+            print notification
+            message_body += notification + "\n"
+            if ('DRY_RUN' not in os.environ or answer_no(os.environ['DRY_RUN'])) \
+                    and ('AGGRESSIVE' in os.environ and answer_yes(os.environ['AGGRESSIVE'])):
+                iam.detach_user_policy(
+                    UserName=user, PolicyArn=policy['PolicyArn'])
+            else:
+                notification = 'AGREESIVE is not active or DRY_RUN is enabled, so the policy is not removed'
+                print notification
+                message_body += notification + "\n"
+
+    if len(users) > 0 and ('DRY_RUN' not in os.environ or answer_no(os.environ['DRY_RUN'])):
+        send_notifications(message_body)
+    else:
+        print 'DRY_RUN is active and/or nothing to do'
+
+
+def lambda_handler(event, context):
+    users = iam.list_users()
+    user_policies = {}
+
+    for user in users['Users']:
+        attached_policy_list = iam.list_attached_user_policies(
+            UserName=user['UserName'])
+        user_policy_list = iam.list_user_policies(UserName=user['UserName'])
+
+        if len(attached_policy_list['AttachedPolicies']) > 0 \
+                or len(user_policy_list['PolicyNames']) > 0:
+
+            user_policies[user['UserName']] = attached_policy_list['AttachedPolicies'] + \
+                user_policy_list['PolicyNames']
+    detach_policies(user_policies)
+
+
+# if __name__ == "__main__":
+#    event = 1
+#    context = 1
+#    lambda_handler(event, context)

--- a/section-1_16.tf
+++ b/section-1_16.tf
@@ -1,0 +1,73 @@
+# AccessKey age check and delete function
+## IAM Policy
+data "template_file" "user_policies_check_policy" {
+  template = "${file("${path.module}/templates/lambda_user_policies_check_policy.json.tpl")}"
+}
+
+resource "aws_iam_role" "user_policies_check" {
+  name               = "${var.resource_name_prefix}-user-policies-check"
+  assume_role_policy = "${data.template_file.iam_lambda_assume_role_policy.rendered}"
+}
+
+resource "aws_iam_role_policy" "user_policies_check" {
+  name   = "${var.resource_name_prefix}-lambda-user-policies-check"
+  role   = "${aws_iam_role.user_policies_check.id}"
+  policy = "${data.template_file.user_policies_check_policy.rendered}"
+}
+
+## /IAM Policy
+
+## Create the function
+data "archive_file" "user_policies_check" {
+  type        = "zip"
+  source_file = "${path.module}/files/user_policies_check.py"
+  output_path = "${var.temp_artifacts_dir}/user_policies_check.zip"
+}
+
+resource "aws_lambda_function" "user_policies_check" {
+  filename         = "${var.temp_artifacts_dir}/user_policies_check.zip"
+  function_name    = "${var.resource_name_prefix}-user-policies-check"
+  role             = "${aws_iam_role.user_policies_check.arn}"
+  handler          = "user_policies_check.lambda_handler"
+  source_code_hash = "${data.archive_file.user_policies_check.output_base64sha256}"
+  runtime          = "python2.7"
+  timeout          = "${var.lambda_timeout}"
+
+  environment {
+    variables = {
+      DRY_RUN                = "${var.lambda_dry_run}"
+      AGGRESSIVE             = "${var.lambda_aggressive}"
+      IGNORE_IAM_USER_PREFIX = "${var.lambda_mfa_checker_user_prefix}"
+      IGNORE_IAM_USER_SUFFIX = "${var.lambda_mfa_checker_user_suffix}"
+    }
+  }
+
+  tags = "${var.tags}"
+}
+
+## /Create the function
+
+## Schedule the lambda function
+resource "aws_cloudwatch_event_rule" "user_policies_check" {
+  name                = "${var.resource_name_prefix}-user-policies-check"
+  description         = "remove expiring access keys"
+  schedule_expression = "${var.lambda_cron_schedule}"
+}
+
+resource "aws_cloudwatch_event_target" "user_policies_check" {
+  rule      = "${aws_cloudwatch_event_rule.user_policies_check.name}"
+  target_id = "${var.resource_name_prefix}-user-policies-check"
+  arn       = "${aws_lambda_function.user_policies_check.arn}"
+}
+
+resource "aws_lambda_permission" "user_policies_check" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = "${aws_lambda_function.user_policies_check.function_name}"
+  principal     = "events.amazonaws.com"
+  source_arn    = "${aws_cloudwatch_event_rule.user_policies_check.arn}"
+}
+
+## /Schedule the lambda function
+# /AccessKey age check and delete function
+

--- a/templates/lambda_user_policies_check_policy.json.tpl
+++ b/templates/lambda_user_policies_check_policy.json.tpl
@@ -1,0 +1,24 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*:*:*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:DetachUserPolicy",
+        "iam:ListUsers",
+        "iam:ListAttachedUserPolicies",
+        "iam:ListUserPolicies"
+      ],
+      "Resource": "*"
+    }
+  ]
+}


### PR DESCRIPTION
```
1.16 Ensure IAM policies are attached only to groups or roles (Scored)
Profile Applicability:
 Level 1 Description:
By default, IAM users, groups, and roles have no access to AWS resources. IAM policies are the means by which privileges are granted to users, groups, or roles. It is recommended that IAM policies be applied directly to groups and roles but not users.
Rationale:
Assigning privileges at the group or role level reduces the complexity of access management as the number of users grow. Reducing access management complexity may in-turn reduce opportunity for a principal to inadvertently receive or retain excessive privileges.

Audit:
Perform the following to determine if policies are attached directly to users:
1. Run the following to get a list of IAM users:
       aws iam list-users --query 'Users[*].UserName' --output text
2. For each user returned, run the following command to determine if any policies are attached to them:
3. If any policies are returned, the user has a direct policy attachment.
Remediation:
Perform the following to create an IAM group and assign a policy to it:
1. Sign in to the AWS Management Console and open the IAM console at https://console.aws.amazon.com/iam/.
2. In the navigation pane, click Groups and then click Create New Group.
3. In the Group Name box, type the name of the group and then click Next Step.
4. In the list of policies, select the check box for each policy that you want to apply to
all members of the group. Then click Next Step.
      aws iam list-attached-user-policies --user-name <iam_user> aws iam list-user-policies --user-name <iam_user>
       41 | P a g e
5. Click Create Group
Perform the following to add a user to a given group:
1. Sign in to the AWS Management Console and open the IAM console at https://console.aws.amazon.com/iam/.
2. In the navigation pane, click Groups
3. Select the group to add a user to
4. Click Add Users To Group
5. Select the users to be added to the group
6. Click Add Users
Perform the following to remove a direct association between a user and policy:
1. Sign in to the AWS Management Console and open the IAM console at https://console.aws.amazon.com/iam/.
2. In the left navigation pane, click on Users
3. For each user:
1. Select the user
2. Click on the Permissions tab
3. Expand Managed Policies
4. Click Detach Policy for each policy
5. Expand Inline Policies
6. Click Remove Policy for each policy
```