### PR TITLE
section 1.17 added

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,16 @@ This Terraform module helps to setup an AWS account with the requirements of  CI
     14. *TODO*: Ensure hardware MFA is enabled for the "root" account (Scored)
     15. *Ensure security questions are registered in the AWS account (Not Scored)* **Cannot be codified**
     16. Ensure IAM policies are attached only to groups or roles (Scored)
+    17. Enable detailed billing (Scored) **[Manual intervention 1](#action-1)**
+
+
+List of manual interventions
+##### Action 1
+AWS API does not support to set up billing reports and the section 1.17 only creates the necessary bucket. The rest should be taken care of manually.
+
+After applying Terraform, a privileged user needs to take following actions
+1. Open https://console.aws.amazon.com/billing/home?#/preference
+2. Enable **Receive Billing Reports**
+3. Type the name of the bucket you've created in section 1.17 into the textbox.
+4. Click **Verify**
+5. Click **Save preferences**

--- a/section-1_17.tf
+++ b/section-1_17.tf
@@ -1,0 +1,17 @@
+data "aws_billing_service_account" "main" {}
+
+data "template_file" "billing_s3_bucket_policy" {
+  template = "${file("${path.module}/templates/billing_s3_bucket_policy.json.tpl")}"
+
+  vars {
+    bucket_name                     = "${var.billing_s3_bucket_name != "" ? "${var.billing_s3_bucket_name}" : "${var.resource_name_prefix}-billing-logs"}"
+    aws_billing_service_account_arn = "${data.aws_billing_service_account.main.arn}"
+  }
+}
+
+resource "aws_s3_bucket" "billing_logs" {
+  bucket = "${var.billing_s3_bucket_name != "" ? "${var.billing_s3_bucket_name}" : "${var.resource_name_prefix}-billing-logs"}"
+  acl    = "private"
+
+  policy = "${var.billing_s3_bucket_policy != "" ? "${var.billing_s3_bucket_policy}" : "${data.template_file.billing_s3_bucket_policy.rendered}"}"
+}

--- a/templates/billing_s3_bucket_policy.json.tpl
+++ b/templates/billing_s3_bucket_policy.json.tpl
@@ -1,0 +1,31 @@
+{
+  "Id": "Policy",
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetBucketAcl",
+        "s3:GetBucketPolicy"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::${bucket_name}",
+      "Principal": {
+        "AWS": [
+          "${aws_billing_service_account_arn}"
+        ]
+      }
+    },
+    {
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::${bucket_name}/*",
+      "Principal": {
+        "AWS": [
+          "${aws_billing_service_account_arn}"
+        ]
+      }
+    }
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -102,3 +102,13 @@ variable "iam_hard_expiry" {
   description = "Everyone needs hard reset for expired passwords"
   default     = true
 }
+
+variable "billing_s3_bucket_name" {
+  description = "S3 bucket name for billing logs"
+  default     = ""
+}
+
+variable "billing_s3_bucket_policy" {
+  description = "Custom S3 bucket policy for billing logs. The default policy will be used if not defined"
+  default     = ""
+}


### PR DESCRIPTION
```
1.17 Enable detailed billing (Scored)
Profile Applicability:
 Level 1 Description:
Enable Detailed Billing to cause the generation of a log record for every event or hourly ongoing activity which incurs cost in an AWS account. These records are aggregated into CSV files of hourly records, and written to an S3 bucket. A CSV (Comma Separated Values) file of billing records is written at least every 24 hours; writing of files is often more frequent.
Rationale:
Detailed Billing records can be used as an overview of AWS activity across the whole of an account, in addition to per-Region CloudTrail, Config and other service-specific JSON-based logs. Billing records can be graphed over time using the Cost Explorer tool, and budgeting alerts can be configured on billing records and pushed to SNS in the event of spend over time, or predicted spend at current rate, going above a customer-set threshold - this can be used as a simple means of detecting anomalous utilisation of AWS resources and thereby triggering investigation activities. Billing records can also be broken out by tag, which can serve as a starting point in identifying which part of the environment, or organisation, the anomalous activity is occurring in.
Audit:
There is currently no AWS CLI support for this operation, so it is necessary to use the Management Console.
As a user with IAM permission to read billing information (aws-portal:ViewBilling):
1. Sign in to the AWS Management Console and open the Billing and Cost Management console at https://console.aws.amazon.com/billing/home#/.
2. On the navigation pane, choose Preferences.
3. Verify whether the “Receive Billing Reports” check box is ticked. If it is not, billing
reports are not being generated.
Remediation:
 43 | P a g e
There is currently no AWS CLI support for this operation, so it is necessary to use the Management Console.
As a user with IAM permission to read and write billing information (aws-portal:*Billing):
 Sign in to the AWS Management Console and open the Billing and Cost Management console at https://console.aws.amazon.com/billing/home#/.
 On the navigation pane, choose Preferences.
 Select the Receive Billing Reports check box.
 Designate the Amazon S3 bucket <S3_billing_bucket> where you want AWS to
publish your detailed billing reports.
 Ensure that policy allows read access only to appropriate groups of users (finance,
auditors, etc). For appropriate groups in IAM who you want to have read access, include the following policy element:
"Statement":[ {
"Effect":"Allow", "Action":[
"s3:GetObject",
"s3:GetObjectVersion”, “s3:GetBucketLocation"
],
"Resource":"arn:aws:s3:::<S3_billing_bucket>/*" }
]
  After your S3 bucket has been verified, under Report, select the check boxes for the reports that you want to receive.
 Choose Save preferences
 Detailed billing reports can take up to 24 hours to start being generated. Wait >24
hours, and examine your designated S3 bucket to verify that files with names of the form (eg) <AWS account number>-<aws-billing-detailed-line-items-with-resources- and-tags-yyyy-mm>.csv.zip are being generated.
```