### PR TITLE
section 1.18 needs a discussion

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This Terraform module helps to setup an AWS account with the requirements of  CI
     15. *Ensure security questions are registered in the AWS account (Not Scored)* **Cannot be codified**
     16. Ensure IAM policies are attached only to groups or roles (Scored)
     17. Enable detailed billing (Scored) **[Manual intervention 1](#action-1)**
+    18. *TODO*: Ensure IAM Master and IAM Manager roles are active (Scored).
 
 
 List of manual interventions

--- a/section-1_18.tf
+++ b/section-1_18.tf
@@ -1,0 +1,2 @@
+# needs to be discussed and planned
+


### PR DESCRIPTION
```
1.18 Ensure IAM Master and IAM Manager roles are active (Scored)
Profile Applicability:
 Level 1 Description:
Ensure IAM Master and IAM Manager roles are in place for IAM administration and assignment of administrative permissions for other services to other roles.
An IAM role is conceptually “a container of permissions resembling a user account which cannot be directly logged into, but which must instead be assumed from an existing user account which has appropriate permissions to do so”, in the manner of roles in Unix Role- Based Access Control (RBAC). In AWS, roles can also be assigned to EC2 instances and Lambda functions.
Control over IAM, which is also defined and mediated by a number of fine-grained permissions, should be divided between a number of roles, such that no individual user in a production account has full control over IAM.
Rationale:
IAM is the principal point of control for service configuration access, and "control over IAM” means “control over the configuration of all other assets in the AWS account”. Therefore it is recommended that control of this degree of security criticality should be divided among multiple individuals within an organisation, in a manner such that no individual retains enough control over IAM to “rewrite themselves to root”.
Roles are recommended for security-sensitive capabilities, as the act of assuming a role generates a set of ephemeral credentials using the Security Token Service (STS) and these credentials - being a token, an AWS Access Key and an AWS Secret Access Key - are needed to make API calls in the context of the role. STS credentials expire after a configurable period (default 12 hours, minimum 15 minutes, maximum 36 hours), and this reduces the risk of engineers hard-wiring these keys into code, and therefore further reduces the risk of the keys being mishandled.
The current recommendation is to divide account and permission configuration permissions between 2 roles, which are:
IAM Master: creates users, groups and roles; assigns permissions to roles IAM Manager: assigns users and roles to groups
In this model, IAM Master and IAM Manager must work together in a 2-person rule manner, in order for a user to gain access to a permission.
```