### PR TITLE
section 1.19. cannot be codified but documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ This Terraform module helps to setup an AWS account with the requirements of  CI
     16. Ensure IAM policies are attached only to groups or roles (Scored)
     17. Enable detailed billing (Scored) **[Manual intervention 1](#action-1)**
     18. *TODO*: Ensure IAM Master and IAM Manager roles are active (Scored).
+    19. Maintain current contact details (Scored) **Cannot be codified** **[Manual intervention 2](#action-2)**
 
 
-List of manual interventions
+# List of manual interventions
 ##### Action 1
 AWS API does not support to set up billing reports and the section 1.17 only creates the necessary bucket. The rest should be taken care of manually.
 
@@ -33,3 +34,7 @@ After applying Terraform, a privileged user needs to take following actions
 3. Type the name of the bucket you've created in section 1.17 into the textbox.
 4. Click **Verify**
 5. Click **Save preferences**
+
+##### Action 2
+AWS API does not support this action, so needs to be completed manually by the root user.
+To find out what needs to be done, please visit https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/manage-account-payment.html#contact-info


### PR DESCRIPTION
```
1.19 Maintain current contact details (Scored)
Profile Applicability:
 Level 1 Description:
Ensure contact email and telephone details for AWS accounts are current and map to more than one individual in your organisation.

An AWS account supports a number of contact details, and AWS will use these to contact the account owner if activity judged to be in breach of Acceptable Use Policy or indicative of likely security compromise is observed by the AWS Abuse team. Contact details should not be for a single individual, as circumstances may arise where that individual is unavailable. Email contact details should point to a mail alias which forwards email to multiple individuals within the organisation; where feasible, phone contact details should point to a PABX hunt group or other call-forwarding system.

Rationale:
If an AWS account is observed to be behaving in a prohibited or suspicious manner, AWS will attempt to contact the account owner by email and phone using the contact details listed. If this is unsuccessful and the account behaviour needs urgent mitigation, proactive measures may be taken, including throttling of traffic between the account exhibiting suspicious behaviour and the AWS API endpoints and the Internet. This will result in impaired service to and from the account in question, so it is in both the customers’ and AWS’ best interests that prompt contact can be established. This is best achieved by setting AWS account contact details to point to resources which have multiple individuals as recipients, such as email aliases and PABX hunt groups.
```