### PR TITLE
section 1.21 added

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This Terraform module helps to setup an AWS account with the requirements of  CI
     18. *TODO*: Ensure IAM Master and IAM Manager roles are active (Scored).
     19. Maintain current contact details (Scored) **Cannot be codified** **[Manual intervention 2](#action-2)**
     20. Ensure security contact information is registered (Scored) **Cannot be codified** **[Manual intervention 2](#action-2)**
+    21. Ensure IAM instance roles are used for AWS resource access from instances (Not Scored)
 
 
 # List of manual interventions

--- a/files/ec2_instances_iam_role_check.py
+++ b/files/ec2_instances_iam_role_check.py
@@ -1,0 +1,65 @@
+import os
+import boto3
+
+
+def answer_no(x): return True if str(x).lower() in [
+    '0', 'no', 'false'] else False
+
+
+def answer_yes(x): return True if str(x).lower() in [
+    '1', 'yes', 'true'] else False
+
+
+def send_notifications(message):
+    # TODO
+    return True
+
+
+def process_regions(regions):
+    message_body = ''
+
+    for region, instances in regions.iteritems():
+        message_body = 'Region ' + region + \
+            " has following instances without an IAM Instance Profile\n"
+        message_body += "\n".join(instances)
+
+    print message_body
+
+    if len(regions) > 0 and ('DRY_RUN' in os.environ and answer_no(os.environ['DRY_RUN'])):
+        send_notifications(message_body)
+    else:
+        print "Nothing to do. Either everything is fine or DRY_RUN is active"
+
+
+def lambda_handler(event, context):
+    regions_to_process = {}
+
+    ec2 = boto3.client('ec2')
+
+    regions = ec2.describe_regions()
+
+    for region in regions['Regions']:
+
+        print 'Processing region ' + region['RegionName']
+
+        # Create a new client for the region
+        ec2_region = boto3.client('ec2', region_name=region['RegionName'])
+        # Create a paginator to filter
+        paginator = ec2_region.get_paginator('describe_instances')
+        page_iterator = paginator.paginate()
+        # Filter with JMESPath and find out instances without an IAM Instance profile
+        filtered_iterator = page_iterator.search(
+            'Reservations[].Instances[].{InstanceId: InstanceId, InstanceProfileArn: IamInstanceProfile.Arn} | [?@.InstanceProfileArn == null].InstanceId')
+
+        for instance in filtered_iterator:
+            if region['RegionName'] not in regions_to_process:
+                regions_to_process.setdefault(region['RegionName'], [])
+            regions_to_process[region['RegionName']].append(instance)
+
+    process_regions(regions_to_process)
+
+
+# if __name__ == "__main__":
+#    event = 1
+#    context = 1
+#    lambda_handler(event, context)

--- a/section-1_21.tf
+++ b/section-1_21.tf
@@ -1,0 +1,70 @@
+# IAM Instance Profile check for instances
+## IAM Policy
+data "template_file" "ec2_instances_iam_role_check_policy" {
+  template = "${file("${path.module}/templates/lambda_ec2_instances_iam_role_check_policy.json.tpl")}"
+}
+
+resource "aws_iam_role" "ec2_instances_iam_role_check" {
+  name               = "${var.resource_name_prefix}-ec2-instances-iam-role-check"
+  assume_role_policy = "${data.template_file.iam_lambda_assume_role_policy.rendered}"
+}
+
+resource "aws_iam_role_policy" "ec2_instances_iam_role_check" {
+  name   = "${var.resource_name_prefix}-lambda-ec2-instances-iam-role-check"
+  role   = "${aws_iam_role.ec2_instances_iam_role_check.id}"
+  policy = "${data.template_file.ec2_instances_iam_role_check_policy.rendered}"
+}
+
+## /IAM Policy
+
+## Create the function
+data "archive_file" "ec2_instances_iam_role_check" {
+  type        = "zip"
+  source_file = "${path.module}/files/ec2_instances_iam_role_check.py"
+  output_path = "${var.temp_artifacts_dir}/ec2_instances_iam_role_check.zip"
+}
+
+resource "aws_lambda_function" "ec2_instances_iam_role_check" {
+  filename         = "${var.temp_artifacts_dir}/ec2_instances_iam_role_check.zip"
+  function_name    = "${var.resource_name_prefix}-ec2-instances-iam-role-check"
+  role             = "${aws_iam_role.ec2_instances_iam_role_check.arn}"
+  handler          = "ec2_instances_iam_role_check.lambda_handler"
+  source_code_hash = "${data.archive_file.ec2_instances_iam_role_check.output_base64sha256}"
+  runtime          = "python2.7"
+  timeout          = "${var.lambda_timeout}"
+
+  environment {
+    variables = {
+      DRY_RUN = "${var.lambda_dry_run}"
+    }
+  }
+
+  tags = "${var.tags}"
+}
+
+## /Create the function
+
+## Schedule the lambda function
+resource "aws_cloudwatch_event_rule" "ec2_instances_iam_role_check" {
+  name                = "${var.resource_name_prefix}-ec2-instances-iam-role-check"
+  description         = "remove expiring access keys"
+  schedule_expression = "${var.lambda_cron_schedule}"
+}
+
+resource "aws_cloudwatch_event_target" "ec2_instances_iam_role_check" {
+  rule      = "${aws_cloudwatch_event_rule.ec2_instances_iam_role_check.name}"
+  target_id = "${var.resource_name_prefix}-ec2-instances-iam-role-check"
+  arn       = "${aws_lambda_function.ec2_instances_iam_role_check.arn}"
+}
+
+resource "aws_lambda_permission" "ec2_instances_iam_role_check" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = "${aws_lambda_function.ec2_instances_iam_role_check.function_name}"
+  principal     = "events.amazonaws.com"
+  source_arn    = "${aws_cloudwatch_event_rule.ec2_instances_iam_role_check.arn}"
+}
+
+## /Schedule the lambda function
+# /IAM Instance Profile check for instances
+

--- a/templates/lambda_ec2_instances_iam_role_check_policy.json.tpl
+++ b/templates/lambda_ec2_instances_iam_role_check_policy.json.tpl
@@ -1,0 +1,22 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*:*:*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeRegions",
+        "ec2:DescribeInstances"
+      ],
+      "Resource": "*"
+    }
+  ]
+}


### PR DESCRIPTION
```
1.21 Ensure IAM instance roles are used for AWS resource access from instances (Not Scored)
Profile Applicability:
 Level 2 Description:
AWS access from within AWS instances can be done by either encoding AWS keys into AWS API calls or by assigning the instance to a role which has an appropriate permissions policy for the required access. "AWS Access" means accessing the APIs of AWS in order to access AWS resources or manage AWS account resources.
Rationale:
AWS IAM roles reduce the risks associated with sharing and rotating credentials that can be used outside of AWS itself. If credentials are compromised, they can be used from outside of the the AWS account they give access to. In contrast, in order to leverage role permissions an attacker would need to gain and maintain access to a specific instance to use the privileges associated with it.
Additionally, if credentials are encoded into compiled applications or other hard to change mechanisms, then they are even more unlikely to be properly rotated due to service disruption risks. As time goes on, credentials that cannot be rotated are more likely to be known by an increasing number of individuals who no longer work for the organization owning the credentials.
```